### PR TITLE
[BUG] Fix - `APPINFO` doesn't exist on vanilla Pip-Boys, so shouldn't hard error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pip-terminal",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pip-terminal",
   "description": "A special terminal for giving you a bit more control over your Pip-Boy 3000 Mk V!",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Cody Tolene <codyatolene@gmail.com>",
   "homepage": "https://pip-boy.com/",
   "private": true,

--- a/src/app/components/pip/actions-apps/pip-actions-apps.component.ts
+++ b/src/app/components/pip/actions-apps/pip-actions-apps.component.ts
@@ -203,6 +203,7 @@ export class PipActionsAppsComponent {
     try {
       const createAppDirSuccess = await this.createDirectoryIfNonExistent(
         this.appMainDirectory,
+        true,
       );
       if (!createAppDirSuccess) {
         return;
@@ -210,6 +211,7 @@ export class PipActionsAppsComponent {
 
       const createAppMetaDirSucess = await this.createDirectoryIfNonExistent(
         this.appMetaDir,
+        true,
       );
       if (!createAppMetaDirSucess) {
         return;
@@ -285,10 +287,16 @@ export class PipActionsAppsComponent {
    * @returns True if the directory was created successfully or already
    * exists, false otherwise.
    */
-  private async createDirectoryIfNonExistent(dir: string): Promise<boolean> {
+  private async createDirectoryIfNonExistent(
+    dir: string,
+    log: boolean,
+  ): Promise<boolean> {
     logMessage(`Ensuring "${dir}" directory exists.`);
 
-    const result = await this.pipFileService.createDirectoryIfNonExistent(dir);
+    const result = await this.pipFileService.createDirectoryIfNonExistent(
+      dir,
+      log,
+    );
 
     if (!result) {
       logMessage(`Failed to create directory "${dir}" on device.`);
@@ -340,8 +348,10 @@ export class PipActionsAppsComponent {
       // For each asset directy, make sure it exists before upload
       for (const [fileName, zipFile] of Object.entries(zip.files)) {
         if (zipFile.dir) {
-          const createDirSuccess =
-            await this.createDirectoryIfNonExistent(fileName);
+          const createDirSuccess = await this.createDirectoryIfNonExistent(
+            fileName,
+            true,
+          );
 
           if (!createDirSuccess) {
             logMessage(`Failed to create directory "${fileName}" on device.`);

--- a/src/app/constants/app-version.ts
+++ b/src/app/constants/app-version.ts
@@ -1,1 +1,1 @@
-export const APP_VERSION = '2.2.0';
+export const APP_VERSION = '2.2.1';

--- a/src/app/services/pip/pip-file.service.ts
+++ b/src/app/services/pip/pip-file.service.ts
@@ -41,6 +41,7 @@ export class PipFileService {
    */
   public async createDirectoryIfNonExistent(
     directory: string,
+    log = false,
   ): Promise<boolean> {
     if (!this.pipConnectionService.connection?.isOpen) {
       logMessage('Please connect to the device first.');
@@ -58,7 +59,9 @@ export class PipFileService {
         );
         return false;
       } else {
-        logMessage(result.message);
+        if (log) {
+          logMessage(result.message);
+        }
         return true;
       }
     } catch (error) {
@@ -232,7 +235,8 @@ export class PipFileService {
     }
 
     try {
-      const fileMetaList = await this.getBranch('APPINFO/');
+      await this.createDirectoryIfNonExistent(this.appMetaDirectory);
+      const fileMetaList = await this.getBranch(`${this.appMetaDirectory}/`);
       const fileMetaListJson =
         fileMetaList?.filter((fileMeta) => fileMeta.path.endsWith('.json')) ??
         [];
@@ -242,7 +246,7 @@ export class PipFileService {
       for (const fileName of fileMetaListJson.map(
         (fileMeta) => fileMeta.name,
       )) {
-        const filePath = `APPINFO/${fileName}`;
+        const filePath = `${this.appMetaDirectory}/${fileName}`;
         const command = Commands.getApps(filePath);
         const fileContent = await this.pipCommandService.run<string>(command);
 


### PR DESCRIPTION
Takes care of task #58 

- [x] Create directory `APPINFO` if it doesn't exist before accessing directory.
- [x] Add log bool to control logging for the creation (we don't want to show "Directory already exists" on every connect)

Thanks to [rikkuness](https://github.com/rikkuness) and S15 Costuming for reporting this bug.
